### PR TITLE
Make handle_dates ignore geometry column

### DIFF
--- a/R/geojson_sf.R
+++ b/R/geojson_sf.R
@@ -152,7 +152,7 @@ date_columns <- function( sf ) names(which(vapply(sf , function(x) { inherits(x,
 
 handle_dates <- function( x ) {
 	dte <- date_columns( x )
-	x[dte] <- lapply(x[dte], as.character)
+	x[dte] <- lapply(as.data.frame(x)[dte], as.character)
 	return( x )
 }
 


### PR DESCRIPTION
I was trying out the development version (because of the fix for Dates/POSIXt), and noticed that it was much slower than the version on CRAN:

```r
# CRAN version
myurl <- "http://eric.clst.org/assets/wiki/uploads/Stuff/gz_2010_us_050_00_500k.json"
sf <- sf::st_read(myurl, quiet = T)
system.time(geojsonsf::sf_geojson(sf))
#>    user  system elapsed 
#>  1.783   0.062   1.855 

# Dev version (with handle_dates)
devtools::install_github("symbolixAU/geojsonsf")
myurl <- "http://eric.clst.org/assets/wiki/uploads/Stuff/gz_2010_us_050_00_500k.json"
sf <- sf::st_read(myurl, quiet = T)

system.time(geojsonsf::sf_geojson(sf))
#>   user  system elapsed 
#>  3.938   0.053   4.002
```

The difference was even more pronounced in the larger object I was working with.

Because the geometry column in sf objects is "sticky", `x[dte]` in the `lapply` [in `handle_dates()`](https://github.com/SymbolixAU/geojsonsf/blob/c418bb0cde545a414b33043e3fc6519133b7ed4b/R/geojson_sf.R#L155) will always include the geometry column, meaning that it will get converted to character (super slow). Converting x to a regular `data.frame` means only the columns matched by `dte` will get converted.