### PR TITLE
Minor: default values for `lon` and `lat` in `df_geojson`.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,7 @@ LinkingTo:
     sfheaders (>= 0.2.2)
 Imports: 
     Rcpp
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.2
 Suggests: 
     covr,
     jsonify,

--- a/R/sf_geojson.R
+++ b/R/sf_geojson.R
@@ -125,29 +125,29 @@ sfc_geojson.default <- function( sfc, digits = NULL ) stop("Expected an sfc obje
 #' @examples
 #'
 #' df <- data.frame(lon = c(1:5, NA), lat = c(1:5, NA), id = 1:6, val = letters[1:6])
-#' df_geojson( df, lon = "lon", lat = "lat")
-#' df_geojson( df, lon = "lon", lat = "lat", atomise = TRUE)
+#' df_geojson( df )
+#' df_geojson( df, atomise = TRUE)
 #'
 #' df <- data.frame(lon = c(1:5, NA), lat = c(1:5, NA) )
-#' df_geojson( df, lon = "lon", lat = "lat")
-#' df_geojson( df, lon = "lon", lat = "lat", simplify = FALSE)
+#' df_geojson( df )
+#' df_geojson( df, simplify = FALSE)
 #'
 #' df <- data.frame(lon = c(1:5), lat = c(1:5), elevation = c(1:5) )
-#' df_geojson( df, lon = "lon", lat = "lat", z = "elevation")
-#' df_geojson( df, lon = "lon", lat = "lat", z = "elevation", simplify = FALSE)
+#' df_geojson( df, z = "elevation")
+#' df_geojson( df, z = "elevation", simplify = FALSE)
 #'
 #' df <- data.frame(lon = c(1:5), lat = c(1:5), elevation = c(1:5), id = 1:5 )
-#' df_geojson( df, lon = "lon", lat = "lat", z = "elevation")
-#' df_geojson( df, lon = "lon", lat = "lat", z = "elevation", atomise = TRUE)
+#' df_geojson( df, z = "elevation")
+#' df_geojson( df, z = "elevation", atomise = TRUE)
 #'
 #'
 #' ## to sf objects
-#' geo <- df_geojson( df, lon = "lon", lat = "lat", z = "elevation")
+#' geo <- df_geojson( df, z = "elevation")
 #' sf <- geojson_sf( geo )
 #'
 #' @export
 df_geojson <- function(
-	df, lon, lat, z = NULL, m = NULL,
+	df, lon = "lon", lat = "lat", z = NULL, m = NULL,
 	atomise = FALSE, simplify = TRUE, digits = NULL,
 	factors_as_string = TRUE
 	) {

--- a/R/sf_geojson.R
+++ b/R/sf_geojson.R
@@ -105,8 +105,10 @@ sfc_geojson.default <- function( sfc, digits = NULL ) stop("Expected an sfc obje
 #' Converts data.frame objects to GeoJSON. Each row is considerd a POINT
 #'
 #' @param df data.frame
-#' @param lon column of \code{df} containing the longitude data
-#' @param lat column of \code{df} containing the latitude data
+#' @param lon character column name of \code{df} containing the longitude data,
+#' defaults to `lon`
+#' @param lat character column name column of \code{df} containing the
+#' latitude data, defaults to `lat`.
 #' @param z column of \code{df} containing the Z attribute of the GeoJSON
 #' @param m column of \code{df} containing the M attribute of the GeoJSON.
 #' If supplied, you must also supply \code{z}

--- a/man/df_geojson.Rd
+++ b/man/df_geojson.Rd
@@ -6,8 +6,8 @@
 \usage{
 df_geojson(
   df,
-  lon,
-  lat,
+  lon = "lon",
+  lat = "lat",
   z = NULL,
   m = NULL,
   atomise = FALSE,
@@ -19,9 +19,11 @@ df_geojson(
 \arguments{
 \item{df}{data.frame}
 
-\item{lon}{column of \code{df} containing the longitude data}
+\item{lon}{character column name of \code{df} containing the longitude data,
+defaults to `lon`}
 
-\item{lat}{column of \code{df} containing the latitude data}
+\item{lat}{character column name column of \code{df} containing the
+latitude data, defaults to `lat`.}
 
 \item{z}{column of \code{df} containing the Z attribute of the GeoJSON}
 
@@ -50,24 +52,24 @@ Converts data.frame objects to GeoJSON. Each row is considerd a POINT
 \examples{
 
 df <- data.frame(lon = c(1:5, NA), lat = c(1:5, NA), id = 1:6, val = letters[1:6])
-df_geojson( df, lon = "lon", lat = "lat")
-df_geojson( df, lon = "lon", lat = "lat", atomise = TRUE)
+df_geojson( df )
+df_geojson( df, atomise = TRUE)
 
 df <- data.frame(lon = c(1:5, NA), lat = c(1:5, NA) )
-df_geojson( df, lon = "lon", lat = "lat")
-df_geojson( df, lon = "lon", lat = "lat", simplify = FALSE)
+df_geojson( df )
+df_geojson( df, simplify = FALSE)
 
 df <- data.frame(lon = c(1:5), lat = c(1:5), elevation = c(1:5) )
-df_geojson( df, lon = "lon", lat = "lat", z = "elevation")
-df_geojson( df, lon = "lon", lat = "lat", z = "elevation", simplify = FALSE)
+df_geojson( df, z = "elevation")
+df_geojson( df, z = "elevation", simplify = FALSE)
 
 df <- data.frame(lon = c(1:5), lat = c(1:5), elevation = c(1:5), id = 1:5 )
-df_geojson( df, lon = "lon", lat = "lat", z = "elevation")
-df_geojson( df, lon = "lon", lat = "lat", z = "elevation", atomise = TRUE)
+df_geojson( df, z = "elevation")
+df_geojson( df, z = "elevation", atomise = TRUE)
 
 
 ## to sf objects
-geo <- df_geojson( df, lon = "lon", lat = "lat", z = "elevation")
+geo <- df_geojson( df, z = "elevation")
 sf <- geojson_sf( geo )
 
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -5,6 +5,11 @@
 
 using namespace Rcpp;
 
+#ifdef RCPP_USE_GLOBAL_ROSTREAM
+Rcpp::Rostream<true>&  Rcpp::Rcout = Rcpp::Rcpp_cout_get();
+Rcpp::Rostream<false>& Rcpp::Rcerr = Rcpp::Rcpp_cerr_get();
+#endif
+
 // rcpp_df_to_geojson_atomise
 Rcpp::StringVector rcpp_df_to_geojson_atomise(Rcpp::DataFrame& df, Rcpp::StringVector& geometry_columns, int& digits, bool& factors_as_string);
 RcppExport SEXP _geojsonsf_rcpp_df_to_geojson_atomise(SEXP dfSEXP, SEXP geometry_columnsSEXP, SEXP digitsSEXP, SEXP factors_as_stringSEXP) {


### PR DESCRIPTION
Minor cont. to add characters "lon" and "lat" as default values for function `df_geojson`. 

It is meant to save new users learning about providing column names, and it should kick-start thinking about detecting column names via `grep` in future.

Could even add `z = elevation`. 

Not quite sure why `devtools::document()` made some changes to a `.cpp` file so happy to "reset" that.