### PR TITLE
Issue 103 - `geojson_sf()` with mixed logicals

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,12 +1,13 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches:
-      - master
+    branches: [main, master]
   pull_request:
-    branches:
-      - master
 
-name: R-CMD-check
+name: R-CMD-check.yaml
+
+permissions: read-all
 
 jobs:
   R-CMD-check:
@@ -18,65 +19,33 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: windows-latest, r: '3.6'}
-          - {os: macOS-latest, r: '3.6'}
-          - {os: macOS-latest, r: 'devel'}
-          - {os: ubuntu-16.04, r: '3.3', rspm: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
-          - {os: ubuntu-16.04, r: '3.4', rspm: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
-          - {os: ubuntu-16.04, r: '3.5', rspm: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
-          - {os: ubuntu-16.04, r: '3.6', rspm: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
+          - {os: macos-latest,   r: 'release'}
+          - {os: windows-latest, r: 'release'}
+          - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
+          - {os: ubuntu-latest,   r: 'release'}
+          - {os: ubuntu-latest,   r: 'oldrel-1'}
 
     env:
-      R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
-      RSPM: ${{ matrix.config.rspm }}
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: r-lib/actions/setup-r@master
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
+          use-public-rspm: true
 
-      - uses: r-lib/actions/setup-pandoc@master
-
-      - name: Query dependencies
-        run: |
-          install.packages('remotes')
-          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
-        shell: Rscript {0}
-
-      - name: Cache R packages
-        if: runner.os != 'Windows'
-        uses: actions/cache@v1
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-r-${{ matrix.config.r }}-${{ hashFiles('.github/depends.Rds') }}
-          restore-keys: ${{ runner.os }}-r-${{ matrix.config.r }}-
+          extra-packages: any::rcmdcheck
+          needs: check
 
-      - name: Install system dependencies
-        if: runner.os == 'Linux'
-        env:
-          RHUB_PLATFORM: linux-x86_64-ubuntu-gcc
-        run: |
-          Rscript -e "remotes::install_github('r-hub/sysreqs')"
-          sysreqs=$(Rscript -e "cat(sysreqs::sysreq_commands('DESCRIPTION'))")
-          sudo -s eval "$sysreqs"
-
-      - name: Install dependencies
-        run: |
-          remotes::install_deps(dependencies = TRUE)
-          remotes::install_cran("rcmdcheck")
-        shell: Rscript {0}
-
-      - name: Check
-        env:
-          _R_CHECK_CRAN_INCOMING_REMOTE_: false
-        run: rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran"), error_on = "warning", check_dir = "check")
-        shell: Rscript {0}
-
-      - name: Upload check results
-        if: failure()
-        uses: actions/upload-artifact@master
+      - uses: r-lib/actions/check-r-package@v2
         with:
-          name: ${{ runner.os }}-r${{ matrix.config.r }}-results
-          path: check
+          upload-snapshots: true
+          build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,15 +22,15 @@ LinkingTo:
     sfheaders (>= 0.4.5)
 Imports: 
     Rcpp
-RoxygenNote: 7.1.0
+RoxygenNote: 7.3.3
 Suggests: 
     covr,
-    jsonify,
+    jsonify (>= 1.2.3),
     knitr,
     rmarkdown,
     tinytest
 VignetteBuilder: knitr
-remotes:
-	https://github.com/dcooley/sfheaders,
-	https://github.com/SymbolixAU/jsonify,
-	https://github.com/SymbolixAU/rapidjsonr
+Remotes:
+	dcooley/sfheaders,
+	SymbolixAU/jsonify,
+	SymbolixAU/rapidjsonr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,8 @@ Title: GeoJSON to Simple Feature Converter
 Version: 2.0.5
 Date: 2024-07-30
 Authors@R: c(
-    person("David", "Cooley", ,"dcooley@symbolix.com.au", role = c("aut", "cre"))
+    person("David", "Cooley", ,"dcooley@symbolix.com.au", role = c("aut", "cre")),
+    person("Andy", "Teucher", ,"andy.teucher@gmail.com", role = "ctb")
     )
 Description: Converts Between GeoJSON and simple feature objects. 
 License: MIT + file LICENSE
@@ -33,4 +34,3 @@ remotes:
 	https://github.com/dcooley/sfheaders,
 	https://github.com/SymbolixAU/jsonify,
 	https://github.com/SymbolixAU/rapidjsonr
-

--- a/README.Rmd
+++ b/README.Rmd
@@ -17,7 +17,7 @@ knitr::opts_chunk$set(
 ![downloads](http://cranlogs.r-pkg.org/badges/grand-total/geojsonsf)
 [![CRAN RStudio mirror downloads](http://cranlogs.r-pkg.org/badges/geojsonsf)](https://CRAN.R-project.org/package=geojsonsf)
 [![Github Stars](https://img.shields.io/github/stars/SymbolixAU/geojsonsf.svg?style=social&label=Github)](https://github.com/SymbolixAU/geojsonsf)
-[![R build status](https://github.com/symbolixau/geojsonsf/workflows/R-CMD-check/badge.svg)](https://github.com/symbolixau/geojsonsf/actions)
+[![R-CMD-check](https://github.com/SymbolixAU/geojsonsf/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/SymbolixAU/geojsonsf/actions/workflows/R-CMD-check.yaml)
 [![Coverage Status](https://codecov.io/github/SymbolixAU/geojsonsf/coverage.svg?branch=master)](https://codecov.io/github/SymbolixAU/geojsonsf?branch=master)
 
 --
@@ -176,7 +176,3 @@ microbenchmark(
 # geojsonsf  709.2268  709.2268  722.0626  722.0626  734.8984  734.8984      2
 #        sf 1867.6840 1867.6840 1958.7968 1958.7968 2049.9097 2049.9097      2
 ```
-
-
-
-

--- a/README.md
+++ b/README.md
@@ -1,14 +1,13 @@
 geojsonsf
 ================
 
-[![CRAN\_Status\_Badge](http://www.r-pkg.org/badges/version/geojsonsf)](https://CRAN.R-project.org/package=geojsonsf)
+[![CRAN_Status_Badge](http://www.r-pkg.org/badges/version/geojsonsf)](https://CRAN.R-project.org/package=geojsonsf)
 ![downloads](http://cranlogs.r-pkg.org/badges/grand-total/geojsonsf)
 [![CRAN RStudio mirror
 downloads](http://cranlogs.r-pkg.org/badges/geojsonsf)](https://CRAN.R-project.org/package=geojsonsf)
 [![Github
 Stars](https://img.shields.io/github/stars/SymbolixAU/geojsonsf.svg?style=social&label=Github)](https://github.com/SymbolixAU/geojsonsf)
-[![R build
-status](https://github.com/symbolixau/geojsonsf/workflows/R-CMD-check/badge.svg)](https://github.com/symbolixau/geojsonsf/actions)
+[![R-CMD-check](https://github.com/SymbolixAU/geojsonsf/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/SymbolixAU/geojsonsf/actions/workflows/R-CMD-check.yaml)
 [![Coverage
 Status](https://codecov.io/github/SymbolixAU/geojsonsf/coverage.svg?branch=master)](https://codecov.io/github/SymbolixAU/geojsonsf?branch=master)
 
@@ -19,18 +18,18 @@ Status](https://codecov.io/github/SymbolixAU/geojsonsf/coverage.svg?branch=maste
 A simple, low-dependency and **fast** converter between GeoJSON and
 Simple Feature objects in R.
 
------
+------------------------------------------------------------------------
 
 **v1.3.2**
 
 Converts
 
-  - GeoJSON –\> `sf`
-  - GeoJSON –\> `sfc`
-  - `sf` –\> GeoJSON
-  - `sfc` –\> GeoJSON
-  - GeoJSON –\> Well-known text
-  - data.frame –\> GeoJSON (POINT only)
+- GeoJSON –\> `sf`
+- GeoJSON –\> `sfc`
+- `sf` –\> GeoJSON
+- `sfc` –\> GeoJSON
+- GeoJSON –\> Well-known text
+- data.frame –\> GeoJSON (POINT only)
 
 As per GeoJSON ([RFC 7946
 specification)](https://tools.ietf.org/html/rfc7946#page-11), foreign
@@ -96,12 +95,10 @@ js <- c(
 sf <- geojson_sf( js )
 sf
 #  Simple feature collection with 3 features and 1 field
-#  geometry type:  GEOMETRY
-#  dimension:      XY
-#  bbox:           xmin: -1 ymin: -1 xmax: 100 ymax: 1
-#  z_range:        zmin: NA zmax: NA
-#  m_range:        mmin: NA mmax: NA
-#  CRS:            4326
+#  Geometry type: GEOMETRY
+#  Dimension:     XY
+#  Bounding box:  xmin: -1 ymin: -1 xmax: 100 ymax: 1
+#  Geodetic CRS:  WGS 84
 #    id                geometry
 #  1 NA             POINT (0 0)
 #  2 NA LINESTRING (-1 -1, 1 1)

--- a/inst/include/geojsonsf/geojson/geojson_properties.hpp
+++ b/inst/include/geojsonsf/geojson/geojson_properties.hpp
@@ -52,8 +52,14 @@ namespace geojson_properties {
 				} else if (existing_type != "Null" && existing_type != type && type != "Null") {
 
 					// allow NULL through so the type is correct when back in R
-					// if it's different, update to be a 'String'
-					property_types[property] = "String";
+					// Treat "True" and "False" as the same type (logical)
+					bool both_logical = (existing_type == "True" || existing_type == "False") && 
+					                    (type == "True" || type == "False");
+					
+					if (!both_logical) {
+						// if it's different, update to be a 'String'
+						property_types[property] = "String";
+					}
 
 				} else if (existing_type == "Null") {
 					// If the first element is NULL, use the new type
@@ -249,7 +255,7 @@ namespace geojson_properties {
 				} else if (value_type == "False") {
 
 					bool this_value = p.value.GetBool();
-					if (type != "False") {
+					if (type != "False" && type != "True") {
 						std::string value = any_to_string(this_value);
 						update_string_vector(properties, key, value, row_index-1);
 					} else {
@@ -260,7 +266,7 @@ namespace geojson_properties {
 				} else if (value_type == "True") {
 
 					bool this_value = p.value.GetBool();
-					if (type != "True") {
+					if (type != "True" && type != "False") {
 						std::string value = any_to_string(this_value);
 						update_string_vector(properties, key, value, row_index-1);
 					} else {
@@ -292,5 +298,3 @@ namespace geojson_properties {
 } // namespace geojsonsf
 
 #endif
-
-

--- a/inst/include/geojsonsf/geojson/geojson_properties.hpp
+++ b/inst/include/geojsonsf/geojson/geojson_properties.hpp
@@ -252,18 +252,7 @@ namespace geojson_properties {
 						update_numeric_vector(properties, key, value, row_index-1);
 					}
 
-				} else if (value_type == "False") {
-
-					bool this_value = p.value.GetBool();
-					if (type != "False" && type != "True") {
-						std::string value = any_to_string(this_value);
-						update_string_vector(properties, key, value, row_index-1);
-					} else {
-						bool value = p.value.GetBool();
-						update_logical_vector(properties, key, value, row_index-1);
-					}
-
-				} else if (value_type == "True") {
+				} else if (value_type == "False" || value_type == "True") {
 
 					bool this_value = p.value.GetBool();
 					if (type != "True" && type != "False") {

--- a/inst/tinytest/test-geojson_sf.R
+++ b/inst/tinytest/test-geojson_sf.R
@@ -105,11 +105,14 @@
 ## Logicals correctly converted
 gj <- '{"type":"FeatureCollection","features":[
   {"type":"Feature","properties":{"a":true},"geometry":{"type":"Point","coordinates":[0.0,0.0]}},
-  {"type":"Feature","properties":{"a":false},"geometry":{"type":"Point","coordinates":[1.0,1.0]}}
+  {"type":"Feature","properties":{"a":false},"geometry":{"type":"Point","coordinates":[1.0,1.0]}},
+  {"type":"Feature","properties":{"a":false},"geometry":{"type":"Point","coordinates":[2.0,2.0]}},
+  {"type":"Feature","properties":{"a":true},"geometry":{"type":"Point","coordinates":[3.0,3.0]}}
 ]}'
 
 sf <- geojson_sf(gj)
 expect_true(is.logical(sf$a))
+expect_equal(sf$a, c(TRUE, FALSE, FALSE, TRUE))
 
 ## works with all false
 gj <- '{"type":"FeatureCollection","features":[

--- a/inst/tinytest/test-geojson_sf.R
+++ b/inst/tinytest/test-geojson_sf.R
@@ -100,3 +100,31 @@
 	out <- geojson_sf( geojson )
 	expect_equal(out[1][[1]], "Münster")
 	expect_equal(names(out)[1], "örtchen")
+
+## Issue 170
+## Logicals correctly converted
+gj <- '{"type":"FeatureCollection","features":[
+  {"type":"Feature","properties":{"a":true},"geometry":{"type":"Point","coordinates":[0.0,0.0]}},
+  {"type":"Feature","properties":{"a":false},"geometry":{"type":"Point","coordinates":[1.0,1.0]}}
+]}'
+
+sf <- geojson_sf(gj)
+expect_true(is.logical(sf$a))
+
+## works with all false
+gj <- '{"type":"FeatureCollection","features":[
+  {"type":"Feature","properties":{"a":false},"geometry":{"type":"Point","coordinates":[0.0,0.0]}},
+  {"type":"Feature","properties":{"a":false},"geometry":{"type":"Point","coordinates":[1.0,1.0]}}
+]}'
+
+sf <- geojson_sf(gj)
+expect_true(is.logical(sf$a))
+
+## works with all true
+gj <- '{"type":"FeatureCollection","features":[
+  {"type":"Feature","properties":{"a":true},"geometry":{"type":"Point","coordinates":[0.0,0.0]}},
+  {"type":"Feature","properties":{"a":true},"geometry":{"type":"Point","coordinates":[1.0,1.0]}}
+]}'
+
+sf <- geojson_sf(gj)
+expect_true(is.logical(sf$a))


### PR DESCRIPTION
This is an attempt to fix #103.

In `get_property_types()`, `property_type` ("True" or "False") essentially just reflects which boolean value was encountered first, but subsequent features can have a different type, so that `type` for a feature can be different from `property_type` for that property. Before, if a property had different types across features, it was immediately converted to "String". I added logic to recognize that `"True"` and `"False"` are the same logical type. 

In `fill_property_vectors()`, it now allows both `true` and `false` values to be stored in the logical vector, regardless of whether the detected type was labeled as "True" or "False".

I added some new tests, which now pass (failed before), but definitely warrants checking my logic!